### PR TITLE
Parents & Educators page mobile adjustments

### DIFF
--- a/sections/Heros/ParentsAndEducatorsHero.tsx
+++ b/sections/Heros/ParentsAndEducatorsHero.tsx
@@ -1,8 +1,8 @@
-import Hero from '@/components/Hero';
-import StandardLayout from '@/components/StandardLayout';
-import Text from '@/components/Text';
-import { Stack } from '@mui/material';
-import { ReactNode } from 'react';
+import Hero from "@/components/Hero";
+import StandardLayout from "@/components/StandardLayout";
+import Text from "@/components/Text";
+import { Stack } from "@mui/material";
+import { ReactNode } from "react";
 
 const ParentsAndEducatorsHero = ({
 	text,
@@ -16,7 +16,7 @@ const ParentsAndEducatorsHero = ({
 	return (
 		<Hero
 			sx={{
-				background: 'linear-gradient(to right, #673BDC, #00B8C5)',
+				background: "linear-gradient(to right, #673BDC, #00B8C5)",
 				pb: {
 					xs: 6,
 					sm: 6,

--- a/sections/Heros/ParentsAndEducatorsHero.tsx
+++ b/sections/Heros/ParentsAndEducatorsHero.tsx
@@ -27,15 +27,13 @@ const ParentsAndEducatorsHero = ({
 			}}
 		>
 			<StandardLayout>
-				<Stack
-					spacing={4}
-				>
+				<Stack spacing={4}>
 					{title ? (
 						<Text
 							variant="h5"
 							sx={{
-								textAlign: 'center',
-								maxWidth: '900px',
+								textAlign: "center",
+								maxWidth: "900px",
 							}}
 						>
 							{title}
@@ -44,8 +42,8 @@ const ParentsAndEducatorsHero = ({
 					<Text
 						variant="h4"
 						sx={{
-							textAlign: 'center',
-							maxWidth: '700px',
+							textAlign: "center",
+							maxWidth: "700px",
 						}}
 					>
 						{text}

--- a/sections/Heros/ParentsAndEducatorsHero.tsx
+++ b/sections/Heros/ParentsAndEducatorsHero.tsx
@@ -28,18 +28,14 @@ const ParentsAndEducatorsHero = ({
 		>
 			<StandardLayout>
 				<Stack
-					sx={{
-						display: 'flex',
-						alignItems: { xs: 'start', sm: 'center' },
-					}}
 					spacing={4}
 				>
 					{title ? (
 						<Text
 							variant="h5"
 							sx={{
+								textAlign: 'center',
 								maxWidth: '900px',
-								textAlign: { xs: 'left', sm: 'center' },
 							}}
 						>
 							{title}
@@ -48,8 +44,8 @@ const ParentsAndEducatorsHero = ({
 					<Text
 						variant="h4"
 						sx={{
+							textAlign: 'center',
 							maxWidth: '700px',
-							textAlign: { xs: 'left', sm: 'center' },
 						}}
 					>
 						{text}
@@ -58,8 +54,8 @@ const ParentsAndEducatorsHero = ({
 						<Text
 							variant="body1"
 							sx={{
+								textAlign: 'center',
 								maxWidth: '700px',
-								textAlign: { xs: 'left', sm: 'center' },
 							}}
 						>
 							{subtext}

--- a/sections/Heros/ParentsAndEducatorsHero.tsx
+++ b/sections/Heros/ParentsAndEducatorsHero.tsx
@@ -27,13 +27,19 @@ const ParentsAndEducatorsHero = ({
 			}}
 		>
 			<StandardLayout>
-				<Stack spacing={4}>
+				<Stack
+					spacing={4}
+					sx={{
+						display: 'flex',
+						alignItems: 'center',
+					}}
+				>
 					{title ? (
 						<Text
 							variant="h5"
 							sx={{
-								textAlign: "center",
-								maxWidth: "900px",
+								textAlign: 'center',
+								maxWidth: '900px',
 							}}
 						>
 							{title}

--- a/sections/Heros/ParentsAndEducatorsHero.tsx
+++ b/sections/Heros/ParentsAndEducatorsHero.tsx
@@ -52,8 +52,8 @@ const ParentsAndEducatorsHero = ({
 						<Text
 							variant="body1"
 							sx={{
-								textAlign: 'center',
-								maxWidth: '700px',
+								textAlign: "center",
+								maxWidth: "700px",
 							}}
 						>
 							{subtext}

--- a/sections/LibrarySection.tsx
+++ b/sections/LibrarySection.tsx
@@ -45,8 +45,8 @@ const LibrarySection = ({ section }: { section: Section }) => {
 			<StandardLayout>
 				<Stack spacing={6}>
 					<Text
-						variant={'h3'}
-						sxMobile={{ textAlign: 'center', fontSize: '32px' }}
+						variant={"h3"}
+						sxMobile={{ textAlign: "center", fontSize: "32px" }}
 					>
 						{title}
 					</Text>

--- a/sections/LibrarySection.tsx
+++ b/sections/LibrarySection.tsx
@@ -1,55 +1,57 @@
 import {
-  Chapter,
-  chapters3to5,
-  chapters6to7,
-  chapters8to12,
-} from "@/content/chapters";
-import LibraryChapters from "@/components/LibraryChapters";
-import StandardLayout from "@/components/StandardLayout";
-import Text from "@/components/Text";
-import { Box, Stack } from "@mui/material";
+	Chapter,
+	chapters3to5,
+	chapters6to7,
+	chapters8to12,
+} from '@/content/chapters';
+import LibraryChapters from '@/components/LibraryChapters';
+import StandardLayout from '@/components/StandardLayout';
+import Text from '@/components/Text';
+import { Box, Stack } from '@mui/material';
 
 export enum Section {
-  THREE_TO_FIVE = "3-5",
-  SIX_TO_SEVEN = "6-7",
-  EIGHT_TO_TWELVE = "8-12",
+	THREE_TO_FIVE = '3-5',
+	SIX_TO_SEVEN = '6-7',
+	EIGHT_TO_TWELVE = '8-12',
 }
 const sections = new Map<
-  Section,
-  { title: string; color: string; chapters: Chapter[] }
+	Section,
+	{ title: string; color: string; chapters: Chapter[] }
 >([
-  [
-    Section.THREE_TO_FIVE,
-    { title: "Grades 3-5", color: "PrimaryBlue", chapters: chapters3to5 },
-  ],
-  [
-    Section.SIX_TO_SEVEN,
-    { title: "Grades 6-7", color: "Blue", chapters: chapters6to7 },
-  ],
-  [
-    Section.EIGHT_TO_TWELVE,
-    { title: "Grades 8-12", color: "PrimaryPurple", chapters: chapters8to12 },
-  ],
+	[
+		Section.THREE_TO_FIVE,
+		{ title: 'Grades 3-5', color: 'PrimaryBlue', chapters: chapters3to5 },
+	],
+	[
+		Section.SIX_TO_SEVEN,
+		{ title: 'Grades 6-7', color: 'Blue', chapters: chapters6to7 },
+	],
+	[
+		Section.EIGHT_TO_TWELVE,
+		{ title: 'Grades 8-12', color: 'PrimaryPurple', chapters: chapters8to12 },
+	],
 ]);
 
 const LibrarySection = ({ section }: { section: Section }) => {
-  const { title, color, chapters } = sections.get(section)!;
+	const { title, color, chapters } = sections.get(section)!;
 
-  return (
-    <Box
-      sx={{
-        py: 6,
-        backgroundColor: `${color}`,
-      }}
-    >
-      <StandardLayout>
-        <Stack spacing={6}>
-          <Text variant={"h3"}>{title}</Text>
-          <LibraryChapters chapters={chapters} />
-        </Stack>
-      </StandardLayout>
-    </Box>
-  );
+	return (
+		<Box
+			sx={{
+				py: 6,
+				backgroundColor: `${color}`,
+			}}
+		>
+			<StandardLayout>
+				<Stack spacing={6}>
+					<Text variant={'h3'} sxMobile={{ textAlign: 'center' }}>
+						{title}
+					</Text>
+					<LibraryChapters chapters={chapters} />
+				</Stack>
+			</StandardLayout>
+		</Box>
+	);
 };
 
 export default LibrarySection;

--- a/sections/LibrarySection.tsx
+++ b/sections/LibrarySection.tsx
@@ -3,16 +3,16 @@ import {
 	chapters3to5,
 	chapters6to7,
 	chapters8to12,
-} from '@/content/chapters';
-import LibraryChapters from '@/components/LibraryChapters';
-import StandardLayout from '@/components/StandardLayout';
-import Text from '@/components/Text';
-import { Box, Stack } from '@mui/material';
+} from "@/content/chapters";
+import LibraryChapters from "@/components/LibraryChapters";
+import StandardLayout from "@/components/StandardLayout";
+import Text from "@/components/Text";
+import { Box, Stack } from "@mui/material";
 
 export enum Section {
-	THREE_TO_FIVE = '3-5',
-	SIX_TO_SEVEN = '6-7',
-	EIGHT_TO_TWELVE = '8-12',
+	THREE_TO_FIVE = "3-5",
+	SIX_TO_SEVEN = "6-7",
+	EIGHT_TO_TWELVE = "8-12",
 }
 const sections = new Map<
 	Section,
@@ -20,15 +20,15 @@ const sections = new Map<
 >([
 	[
 		Section.THREE_TO_FIVE,
-		{ title: 'Grades 3-5', color: 'PrimaryBlue', chapters: chapters3to5 },
+		{ title: "Grades 3-5", color: "PrimaryBlue", chapters: chapters3to5 },
 	],
 	[
 		Section.SIX_TO_SEVEN,
-		{ title: 'Grades 6-7', color: 'Blue', chapters: chapters6to7 },
+		{ title: "Grades 6-7", color: "Blue", chapters: chapters6to7 },
 	],
 	[
 		Section.EIGHT_TO_TWELVE,
-		{ title: 'Grades 8-12', color: 'PrimaryPurple', chapters: chapters8to12 },
+		{ title: "Grades 8-12", color: "PrimaryPurple", chapters: chapters8to12 },
 	],
 ]);
 

--- a/sections/LibrarySection.tsx
+++ b/sections/LibrarySection.tsx
@@ -44,7 +44,10 @@ const LibrarySection = ({ section }: { section: Section }) => {
 		>
 			<StandardLayout>
 				<Stack spacing={6}>
-					<Text variant={'h3'} sxMobile={{ textAlign: 'center' }}>
+					<Text
+						variant={'h3'}
+						sxMobile={{ textAlign: 'center', fontSize: '32px' }}
+					>
 						{title}
 					</Text>
 					<LibraryChapters chapters={chapters} />

--- a/sections/ParentsAndEducators/EducatorGuidesInfo.tsx
+++ b/sections/ParentsAndEducators/EducatorGuidesInfo.tsx
@@ -1,33 +1,33 @@
-'use client';
+"use client";
 
-import StandardLayout from '@/components/StandardLayout';
-import { Box, Link, Stack } from '@mui/material';
+import StandardLayout from "@/components/StandardLayout";
+import { Box, Link, Stack } from "@mui/material";
 
-import Image from 'next/image';
+import Image from "next/image";
 
-import Text from '@/components/Text';
-import TwoColumnLayout, { ColumnWrapOrder } from '@/components/TwoColumnLayout';
-import useDevice from '@/hooks/useDevice';
+import Text from "@/components/Text";
+import TwoColumnLayout, { ColumnWrapOrder } from "@/components/TwoColumnLayout";
+import useDevice from "@/hooks/useDevice";
 
 const DownloadGuidesButtons = () => {
 	const linkStyles = {
-		color: 'PrimaryPurple',
-		backgroundColor: 'white',
+		color: "PrimaryPurple",
+		backgroundColor: "white",
 		borderRadius: 12,
 		py: 1,
 		px: 2,
-		textDecoration: 'none',
-		fontSize: '16px',
-		fontWeight: 'bold',
-		maxWidth: '332px',
+		textDecoration: "none",
+		fontSize: "16px",
+		fontWeight: "bold",
+		maxWidth: "332px",
 	};
 
 	return (
-		<Stack spacing={4} sx={{ textAlign: 'center' }} mt={6}>
+		<Stack spacing={4} sx={{ textAlign: "center" }} mt={6}>
 			<Stack
-				direction={{ xs: 'column', sm: 'row' }}
+				direction={{ xs: "column", sm: "row" }}
 				spacing={2}
-				sx={{ marginX: 'auto' }}
+				sx={{ marginX: "auto" }}
 				justifyContent="center"
 				alignItems="center"
 			>

--- a/sections/ParentsAndEducators/EducatorGuidesInfo.tsx
+++ b/sections/ParentsAndEducators/EducatorGuidesInfo.tsx
@@ -102,12 +102,12 @@ const EducatorGuidesInfo = () => {
 							<Text
 								variant="h6"
 								sx={{
-									backgroundColor: 'PrimaryBlue',
+									backgroundColor: "PrimaryBlue",
 									py: 1,
 									px: 2,
 									borderRadius: 8,
-									width: 'fit-content',
-									fontSize: '16px',
+									width: "fit-content",
+									fontSize: "16px",
 								}}
 							>
 								NOW AVAILABLE!
@@ -123,8 +123,8 @@ const EducatorGuidesInfo = () => {
 							<Text variant="h6">Each guide includes:</Text>
 							<ul
 								style={{
-									listStyleType: 'square',
-									paddingLeft: '20px',
+									listStyleType: "square",
+									paddingLeft: "20px",
 								}}
 							>
 								<li>Essential background information on the topic</li>

--- a/sections/ParentsAndEducators/EducatorGuidesInfo.tsx
+++ b/sections/ParentsAndEducators/EducatorGuidesInfo.tsx
@@ -49,9 +49,9 @@ const DownloadGuidesButtons = () => {
 			<Text
 				variant="body1"
 				sx={{
-					width: { xs: '90%', md: '472px' },
-					marginX: 'auto',
-					textAlign: 'center',
+					width: { xs: "90%", md: "472px" },
+					marginX: "auto",
+					textAlign: "center",
 				}}
 			>
 				Alternatively, browse the library below to download individual assets or
@@ -80,18 +80,18 @@ const EducatorGuidesInfo = () => {
 					<Box
 						sx={{
 							img: {
-								maxWidth: { xs: '50%', md: '100%' },
-								height: 'auto',
-								borderRadius: '16px',
-								marginX: 'auto',
+								maxWidth: { xs: "50%", md: "100%" },
+								height: "auto",
+								borderRadius: "16px",
+								marginX: "auto",
 								marginBottom: { xs: 4, md: 0 },
 							},
-							display: 'flex',
+							display: "flex",
 						}}
 					>
 						<Image
-							src={'/images/EFG-PDFs-Stacked.png'}
-							alt={'Two PDFs stacked on top of each other'}
+							src={"/images/EFG-PDFs-Stacked.png"}
+							alt={"Two PDFs stacked on top of each other"}
 							width={800}
 							height={400}
 						/>

--- a/sections/ParentsAndEducators/EducatorGuidesInfo.tsx
+++ b/sections/ParentsAndEducators/EducatorGuidesInfo.tsx
@@ -77,26 +77,26 @@ const EducatorGuidesInfo = () => {
 					leftCol={5}
 					rightCol={6}
 				>
-					{!isMobile ? (
-						<Box
-							sx={{
-								img: {
-									maxWidth: { xs: '50%', md: '100%' },
-									height: 'auto',
-									borderRadius: '16px',
-								},
-							}}
-						>
-							<Image
-								src={'/images/EFG-PDFs-Stacked.png'}
-								alt={'Two PDFs stacked on top of each other'}
-								width={800}
-								height={400}
-							/>
-						</Box>
-					) : (
-						<></>
-					)}
+					<Box
+						sx={{
+							img: {
+								maxWidth: { xs: '50%', md: '100%' },
+								height: 'auto',
+								borderRadius: '16px',
+								marginX: 'auto',
+								marginBottom: { xs: 4, md: 0 },
+							},
+							display: 'flex',
+						}}
+					>
+						<Image
+							src={'/images/EFG-PDFs-Stacked.png'}
+							alt={'Two PDFs stacked on top of each other'}
+							width={800}
+							height={400}
+						/>
+					</Box>
+
 					<Box>
 						<Stack spacing={3}>
 							<Text

--- a/sections/ParentsAndEducators/LibraryTitle.tsx
+++ b/sections/ParentsAndEducators/LibraryTitle.tsx
@@ -6,10 +6,10 @@ const LibraryTitle = () => {
 		<StandardLayout
 			sx={{
 				backgroundColor: 'PrimaryBlue',
-				padding: 6,
+				padding: { xs: 4, md: 6 },
 			}}
 		>
-			<Text variant="h3" sx={{ textAlign: 'center' }}>
+			<Text variant="h3" sx={{ textAlign: 'center', fontSize: {xs: '36px', md:'44px'} }}>
 				The Prevention Project Library
 			</Text>
 		</StandardLayout>

--- a/sections/ParentsAndEducators/LibraryTitle.tsx
+++ b/sections/ParentsAndEducators/LibraryTitle.tsx
@@ -1,15 +1,18 @@
-import StandardLayout from '@/components/StandardLayout';
-import Text from '@/components/Text';
+import StandardLayout from "@/components/StandardLayout";
+import Text from "@/components/Text";
 
 const LibraryTitle = () => {
 	return (
 		<StandardLayout
 			sx={{
-				backgroundColor: 'PrimaryBlue',
+				backgroundColor: "PrimaryBlue",
 				padding: { xs: 4, md: 6 },
 			}}
 		>
-			<Text variant="h3" sx={{ textAlign: 'center', fontSize: {xs: '36px', md:'44px'} }}>
+			<Text
+				variant="h3"
+				sx={{ textAlign: "center", fontSize: { xs: "36px", md: "44px" } }}
+			>
 				The Prevention Project Library
 			</Text>
 		</StandardLayout>

--- a/sections/ParentsAndEducators/Questions.tsx
+++ b/sections/ParentsAndEducators/Questions.tsx
@@ -1,33 +1,33 @@
-import StandardLayout from '@/components/StandardLayout';
-import Text from '@/components/Text';
-import { Stack, Link } from '@mui/material';
+import StandardLayout from "@/components/StandardLayout";
+import Text from "@/components/Text";
+import { Stack, Link } from "@mui/material";
 
 const QuestionsSection = () => {
 	return (
-		<StandardLayout sx={{ py: 6, marginX: 'auto' }}>
+		<StandardLayout sx={{ py: 6, marginX: "auto" }}>
 			<Stack
 				direction="column"
 				justifyContent="center"
 				alignItems="center"
 				spacing={2}
-				maxWidth={{ md: '497px' }}
+				maxWidth={{ md: "497px" }}
 			>
-				<Text variant={'h4'} color="PrimaryPurple" sx={{ mb: 2 }}>
+				<Text variant={"h4"} color="PrimaryPurple" sx={{ mb: 2 }}>
 					Questions?
 				</Text>
-				<Text variant={'h6'} color="PrimaryPurple" sx={{ fontSize: '20px' }}>
+				<Text variant={"h6"} color="PrimaryPurple" sx={{ fontSize: "20px" }}>
 					We&apos;re here to help.
 				</Text>
-				<Text variant={'body1'} color={'Grey900'} sx={{ textAlign: 'center' }}>
-					If you need further support, reach out to us by emailing{' '}
+				<Text variant={"body1"} color={"Grey900"} sx={{ textAlign: "center" }}>
+					If you need further support, reach out to us by emailing{" "}
 					<Link
 						href="mailto:thepreventionproject@ally.org"
-						sx={{ color: 'PrimaryPurple' }}
+						sx={{ color: "PrimaryPurple" }}
 					>
 						thepreventionproject@ally.org
-					</Link>{' '}
-					We&apos;re committed to ensuring you feel equipped and empowered to use The
-					Prevention Project effectively.
+					</Link>{" "}
+					We&apos;re committed to ensuring you feel equipped and empowered to
+					use The Prevention Project effectively.
 				</Text>
 			</Stack>
 		</StandardLayout>

--- a/sections/ParentsAndEducators/Questions.tsx
+++ b/sections/ParentsAndEducators/Questions.tsx
@@ -10,13 +10,13 @@ const QuestionsSection = () => {
 				justifyContent="center"
 				alignItems="center"
 				spacing={2}
-				width={{ xs: '90%', sm: '90%', md: '497px' }}
+				maxWidth={{ md: '497px' }}
 			>
 				<Text variant={'h4'} color="PrimaryPurple" sx={{ mb: 2 }}>
 					Questions?
 				</Text>
 				<Text variant={'h6'} color="PrimaryPurple" sx={{ fontSize: '20px' }}>
-					We're here to help.
+					We&apos;re here to help.
 				</Text>
 				<Text variant={'body1'} color={'Grey900'} sx={{ textAlign: 'center' }}>
 					If you need further support, reach out to us by emailing{' '}
@@ -26,7 +26,7 @@ const QuestionsSection = () => {
 					>
 						thepreventionproject@ally.org
 					</Link>{' '}
-					We're committed to ensuring you feel equipped and empowered to use The
+					We&apos;re committed to ensuring you feel equipped and empowered to use The
 					Prevention Project effectively.
 				</Text>
 			</Stack>


### PR DESCRIPTION
- Heading block — text should all be centre-aligned, not left-aligned

- Guide Block — missing mockup image. Please include at the top of the block before any text (above Now Available)

- Library — “TPP Library” text should be larger”, “Grades x-x” should be centre-aligned

| Before | After |
|--------|--------|
| <img width="278" alt="image" src="https://github.com/user-attachments/assets/ee9ba4b8-1d4b-4615-9fd3-3b2af05a4ac8"> | <img width="372" alt="image" src="https://github.com/user-attachments/assets/c2f76274-0776-4183-a640-6629277bf327"> |
| <img width="270" alt="image" src="https://github.com/user-attachments/assets/670d4ddd-abd4-4d63-8615-d3cc91c25ef5"> | <img width="372" alt="image" src="https://github.com/user-attachments/assets/d23c2d5a-9a34-4c5c-86f2-8f32b8148880"> |
| <img width="274" alt="image" src="https://github.com/user-attachments/assets/f25d04de-156b-41b9-8039-6155488a4d2c"> | <img width="365" alt="image" src="https://github.com/user-attachments/assets/98fd69a8-8e30-490f-85b7-31c2f197cbf1"> | 

