### PR TITLE
09 09 2025 hide donation buttons

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -21,9 +21,9 @@ export default function About() {
       <Box id={"book-a-presentation"}>
         <LearnMore />
       </Box>
-      <Box id={"donate"}>
+      {/* <Box id={"donate"}>
         <Donate />
-      </Box>
+      </Box> */}
       <Box id={"acknowledgements"}>
         <Acknowledgements />
       </Box>

--- a/components/ExpandedChapter.tsx
+++ b/components/ExpandedChapter.tsx
@@ -110,13 +110,15 @@ const ExpandedChapter = ({
             <Box
               sx={{
                 mb: 3,
-                ...(content[selected].backgroundImage ? {
-                  backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.5)), url(${content[selected].backgroundImage})`,
-                  backgroundSize: "cover",
-                  backgroundPosition: "top",
-                } : {
-                  backgroundColor: "Grey300",
-                }),
+                ...(content[selected].backgroundImage
+                  ? {
+                      backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.5)), url(${content[selected].backgroundImage})`,
+                      backgroundSize: "cover",
+                      backgroundPosition: "top",
+                    }
+                  : {
+                      backgroundColor: "Grey300",
+                    }),
                 borderRadius: "16px",
                 display: "flex",
                 justifyContent: "center",
@@ -124,7 +126,7 @@ const ExpandedChapter = ({
                 minHeight: { xs: "240px", sm: "396px" },
               }}
             >
-              <Link
+              {/* <Link
                 target="_blank"
                 href={content[selected].pdfUrl!}
                 style={{ textDecoration: "none" }}
@@ -138,7 +140,7 @@ const ExpandedChapter = ({
                   color={"PrimaryBlue"}
                   endIcon={<CloudDownloadOutlinedIcon />}
                 />
-              </Link>
+              </Link> */}
             </Box>
           )}
         </Box>
@@ -158,7 +160,7 @@ const ExpandedChapter = ({
           gap: 1,
         }}
       >
-        {content[selected].vimeoDownloadUrl && (
+        {/* {content[selected].vimeoDownloadUrl && (
           <Link
             target="_blank"
             href={content[selected].vimeoDownloadUrl!}
@@ -170,8 +172,8 @@ const ExpandedChapter = ({
               endIcon={<CloudDownloadOutlinedIcon />}
             />
           </Link>
-        )}
-        {chapterDownloadUrl && (
+        )} */}
+        {/* {chapterDownloadUrl && (
           <Link
             target="_blank"
             href={chapterDownloadUrl}
@@ -183,7 +185,7 @@ const ExpandedChapter = ({
               endIcon={<CloudDownloadOutlinedIcon />}
             />
           </Link>
-        )}
+        )} */}
       </Stack>
     </Box>
   );

--- a/components/ExpandedChapter.tsx
+++ b/components/ExpandedChapter.tsx
@@ -160,6 +160,11 @@ const ExpandedChapter = ({
           gap: 1,
         }}
       >
+        <Box sx={{ backgroundColor: "#FFFFC5", padding: 2, borderRadius: 4 }}>
+          <Text variant={"body2"} color={"Grey800"}>
+            Downloads are temporarily unavailable
+          </Text>
+        </Box>
         {/* {content[selected].vimeoDownloadUrl && (
           <Link
             target="_blank"

--- a/sections/ContentSection.tsx
+++ b/sections/ContentSection.tsx
@@ -23,21 +23,38 @@ const ContentSection = ({ chapters }: { chapters: Chapter[] }) => {
   const section = sectionParam ? Number(sectionParam) : 1;
 
   const selectedChapterSection = chapters[chapter].content[section - 1];
-	const filteredChapters = chapters[chapter].content.filter((chapter) => chapter.hideOnGradesPage !== true);
+  const filteredChapters = chapters[chapter].content.filter(
+    (chapter) => chapter.hideOnGradesPage !== true
+  );
 
   return (
     <>
       <Box sx={{ backgroundColor: "White", pb: { xs: 4, sm: 10, md: 20 } }}>
         <StandardLayout>
           <Stack spacing={2} sx={{ pt: 2 }}>
-            <VideoMenu
-              content={filteredChapters.map((c) => c.title)}
-            />
+            <VideoMenu content={filteredChapters.map((c) => c.title)} />
             {selectedChapterSection.vimeoId && (
               <VideoPlayer vimeoId={selectedChapterSection.vimeoId} />
             )}
             {selectedChapterSection.pdfUrl && (
-              <PdfViewer pathToFile={selectedChapterSection.pdfUrl} />
+              // <PdfViewer pathToFile={selectedChapterSection.pdfUrl} />
+              <Box
+                sx={{
+                  backgroundColor: "#FFFFC5",
+                  padding: 4,
+                  mt: 4,
+                  mx: { xs: 0, sm: 4 },
+                  borderRadius: "8px",
+                }}
+              >
+                <Text
+                  variant={"body1"}
+                  color={"Grey900"}
+                  sx={{ fontStyle: "italic" }}
+                >
+                  This content is temporarily unavailable
+                </Text>
+              </Box>
             )}
           </Stack>
           <Box

--- a/sections/Footer.tsx
+++ b/sections/Footer.tsx
@@ -183,14 +183,17 @@ const Footer = () => {
                     color={`Grey800`}
                     lineHeight={"24px"}
                   >
-                    Email us at <Typography
+                    Email us at{" "}
+                    <Typography
                       component={"a"}
                       href="mailto:info@thepreventionproject.ca"
                       target="_blank"
                       color="Grey800"
                       variant={"caption"}
                       lineHeight={"24px"}
-                    >info@thepreventionproject.ca</Typography>
+                    >
+                      info@thepreventionproject.ca
+                    </Typography>
                   </Typography>
                   <Box>
                     <Typography
@@ -210,6 +213,16 @@ const Footer = () => {
                       lineHeight={"24px"}
                     >
                       prevention-project.org
+                    </Typography>
+                    <Typography
+                      variant={"caption"}
+                      color={`Grey800`}
+                      lineHeight={"24px"}
+                      display={"block"}
+                      sx={{ mt: 6 }}
+                    >
+                      ALL RIGHTS RESERVED. COPYING, DOWNLOADING, DISTRIBUTION OR
+                      REPRODUCTION OF THE CONTENT ON THIS WEBSITE IS PROHIBITED.
                     </Typography>
                   </Box>
                 </Box>

--- a/sections/Footer.tsx
+++ b/sections/Footer.tsx
@@ -139,7 +139,7 @@ const Footer = () => {
                     text={"Book a Presentation"}
                     href="/about#book-a-presentation"
                   />
-                  <FooterItem text={"Donate"} href="/about#donate" />
+                  {/* <FooterItem text={"Donate"} href="/about#donate" /> */}
                   <FooterItem
                     text={"Acknowledgements"}
                     href="/about#acknowledgements"

--- a/sections/Footer.tsx
+++ b/sections/Footer.tsx
@@ -239,7 +239,7 @@ const Footer = () => {
         }}
       >
         <Typography variant={"caption"} color={"Grey800"}>
-          © 2024 Ally Global Foundation
+          © {new Date().getFullYear()} Ally Global Foundation
         </Typography>
         <Box
           sx={{ display: "flex", gap: { xs: 2, sm: 2, md: 4 }, mt: "-10px" }}

--- a/sections/ParentsAndEducators/EducatorGuidesInfo.tsx
+++ b/sections/ParentsAndEducators/EducatorGuidesInfo.tsx
@@ -10,21 +10,21 @@ import TwoColumnLayout, { ColumnWrapOrder } from "@/components/TwoColumnLayout";
 import useDevice from "@/hooks/useDevice";
 
 const DownloadGuidesButtons = () => {
-	const linkStyles = {
-		color: "PrimaryPurple",
-		backgroundColor: "white",
-		borderRadius: 12,
-		py: 1,
-		px: 2,
-		textDecoration: "none",
-		fontSize: "16px",
-		fontWeight: "bold",
-		maxWidth: "332px",
-	};
+  const linkStyles = {
+    color: "PrimaryPurple",
+    backgroundColor: "white",
+    borderRadius: 12,
+    py: 1,
+    px: 2,
+    textDecoration: "none",
+    fontSize: "16px",
+    fontWeight: "bold",
+    maxWidth: "332px",
+  };
 
-	return (
-		<Stack spacing={4} sx={{ textAlign: "center" }} mt={6}>
-			<Stack
+  return (
+    <Stack spacing={4} sx={{ textAlign: "center" }} mt={6}>
+      {/* <Stack
 				direction={{ xs: "column", sm: "row" }}
 				spacing={2}
 				sx={{ marginX: "auto" }}
@@ -45,104 +45,104 @@ const DownloadGuidesButtons = () => {
 				>
 					DOWNLOAD FULL LIBRARY OF RESOURCES
 				</Link>
-			</Stack>
-			<Text
-				variant="body1"
-				sx={{
-					width: { xs: "90%", md: "472px" },
-					marginX: "auto",
-					textAlign: "center",
-				}}
-			>
-				Alternatively, browse the library below to download individual assets or
-				specific chapters.
-			</Text>
-		</Stack>
-	);
+			</Stack> */}
+      {/* <Text
+        variant="body1"
+        sx={{
+          width: { xs: "90%", md: "472px" },
+          marginX: "auto",
+          textAlign: "center",
+        }}
+      >
+        Alternatively, browse the library below to download individual assets or
+        specific chapters.
+      </Text> */}
+    </Stack>
+  );
 };
 
 const EducatorGuidesInfo = () => {
-	const { smScreen: isMobile } = useDevice();
+  const { smScreen: isMobile } = useDevice();
 
-	return (
-		<Box
-			sx={{
-				background: `linear-gradient(90deg, #673BDC 0%, #00B8C5 100%)`,
-				py: { xs: 6, sm: 8 },
-			}}
-		>
-			<StandardLayout>
-				<TwoColumnLayout
-					columnWrapOrderOnMobile={ColumnWrapOrder.NORMAL}
-					leftCol={5}
-					rightCol={6}
-				>
-					<Box
-						sx={{
-							img: {
-								maxWidth: { xs: "50%", md: "100%" },
-								height: "auto",
-								borderRadius: "16px",
-								marginX: "auto",
-								marginBottom: { xs: 4, md: 0 },
-							},
-							display: "flex",
-						}}
-					>
-						<Image
-							src={"/images/EFG-PDFs-Stacked.png"}
-							alt={"Two PDFs stacked on top of each other"}
-							width={800}
-							height={400}
-						/>
-					</Box>
+  return (
+    <Box
+      sx={{
+        background: `linear-gradient(90deg, #673BDC 0%, #00B8C5 100%)`,
+        py: { xs: 6, sm: 8 },
+      }}
+    >
+      <StandardLayout>
+        <TwoColumnLayout
+          columnWrapOrderOnMobile={ColumnWrapOrder.NORMAL}
+          leftCol={5}
+          rightCol={6}
+        >
+          <Box
+            sx={{
+              img: {
+                maxWidth: { xs: "50%", md: "100%" },
+                height: "auto",
+                borderRadius: "16px",
+                marginX: "auto",
+                marginBottom: { xs: 4, md: 0 },
+              },
+              display: "flex",
+            }}
+          >
+            <Image
+              src={"/images/EFG-PDFs-Stacked.png"}
+              alt={"Two PDFs stacked on top of each other"}
+              width={800}
+              height={400}
+            />
+          </Box>
 
-					<Box>
-						<Stack spacing={3}>
-							<Text
-								variant="h6"
-								sx={{
-									backgroundColor: "PrimaryBlue",
-									py: 1,
-									px: 2,
-									borderRadius: 8,
-									width: "fit-content",
-									fontSize: "16px",
-								}}
-							>
-								NOW AVAILABLE!
-							</Text>
-							<Text variant="h4">Educator Facilitation Guides</Text>
+          <Box>
+            <Stack spacing={3}>
+              <Text
+                variant="h6"
+                sx={{
+                  backgroundColor: "PrimaryBlue",
+                  py: 1,
+                  px: 2,
+                  borderRadius: 8,
+                  width: "fit-content",
+                  fontSize: "16px",
+                }}
+              >
+                NOW AVAILABLE!
+              </Text>
+              <Text variant="h4">Educator Facilitation Guides</Text>
 
-							<Text variant="body1">
-								These guides are designed to support classroom teachers, parents
-								and youth leaders as they facilitate The Prevention Project
-								resources with children and youth.
-							</Text>
+              <Text variant="body1">
+                These guides are designed to support classroom teachers, parents
+                and youth leaders as they facilitate The Prevention Project
+                resources with children and youth.
+              </Text>
 
-							<Text variant="h6">Each guide includes:</Text>
-							<ul
-								style={{
-									listStyleType: "square",
-									paddingLeft: "20px",
-								}}
-							>
-								<li>Essential background information on the topic</li>
-								<li>Strategies for moderating sensitive discussions</li>
-								<li>Tips for creating a safe environment for sharing</li>
-								<li>Answers to commonly asked questions</li>
-								<li>Extension activities</li>
-								<li>
-									Links to additional resources beyond The Prevention Project
-								</li>
-							</ul>
-						</Stack>
-					</Box>
-				</TwoColumnLayout>
-				<DownloadGuidesButtons />
-			</StandardLayout>
-		</Box>
-	);
+              <Text variant="h6">Each guide includes:</Text>
+              <ul
+                style={{
+                  listStyleType: "square",
+                  paddingLeft: "20px",
+                }}
+              >
+                <li>Essential background information on the topic</li>
+                <li>Strategies for moderating sensitive discussions</li>
+                <li>Tips for creating a safe environment for sharing</li>
+                <li>Answers to commonly asked questions</li>
+                <li>Extension activities</li>
+                <li>
+                  Links to additional resources beyond The Prevention Project
+                </li>
+              </ul>
+            </Stack>
+          </Box>
+        </TwoColumnLayout>
+        <DownloadGuidesButtons />
+      </StandardLayout>
+    </Box>
+  );
 };
 
 export default EducatorGuidesInfo;


### PR DESCRIPTION
We need to temporarily disable the donate link from the website. This PR changes the following:
- Hides the `Donate` link from the footer by commenting it out. 
- Hides the Donate section from the about page by commenting it out.

As a bonus, I updated the footer year from 2024 to the current year using `Date`